### PR TITLE
Updated pwm controller with pwm to thrust slopes

### DIFF
--- a/riptide_controllers/include/riptide_controllers/pwm_controller.h
+++ b/riptide_controllers/include/riptide_controllers/pwm_controller.h
@@ -19,8 +19,10 @@ class ThrustCal
   ros::Time alive;
   bool dead, low;
   double min_voltage;
-  int counterclockwise(double raw_force);
-  int clockwise(double raw_force);
+  int counterclockwise(double raw_force, int thruster);
+  int clockwise(double raw_force, int thruster);
+  float ccw_coeffs[4][2]; //counterclockwise thrust slopes
+  float cw_coeffs[4][2]; //clockwise thrust slopes
 
  public:
   ThrustCal();

--- a/riptide_controllers/src/pwm_controller.cpp
+++ b/riptide_controllers/src/pwm_controller.cpp
@@ -19,24 +19,47 @@ ThrustCal::ThrustCal() : nh()
   kill_it_with_fire = nh.subscribe<std_msgs::Empty>("state/kill", 1, &ThrustCal::killback, this);
   outta_juice = nh.subscribe<riptide_msgs::Bat>("state/batteries", 1, &ThrustCal::voltsbacken, this);
   pwm = nh.advertise<riptide_msgs::PwmStamped>("command/pwm", 1);
+
+  //Initialization of the two trust/pwm slope arrays
+  //The first column is for negative force, second column is positive force
+
+  ccw_coeffs[0][0] = -24.4498;
+  ccw_coeffs[0][1] = -28.0898;
+  ccw_coeffs[1][0] = 30.2115;
+  ccw_coeffs[1][1] = 23.3645;
+  ccw_coeffs[2][0] = -23.9234;
+  ccw_coeffs[2][1] = -28.4091;
+  ccw_coeffs[3][0] = -23.9810;
+  ccw_coeffs[3][1] = -27.47;
+
+  cw_coeffs[0][0] = 29.1545;
+  cw_coeffs[0][1] = 23.8095;
+  cw_coeffs[1][0] = -24.8138;
+  cw_coeffs[1][1] = -28.49;
+  cw_coeffs[2][0] = 34.7222;
+  cw_coeffs[2][1] = 25.5754;
+  cw_coeffs[3][0] = -30.1205;
+  cw_coeffs[3][1] = -22.6244;
+
 }
 
 void ThrustCal::callback(const riptide_msgs::ThrustStamped::ConstPtr& thrust)
 {
   us.header.stamp = thrust->header.stamp;
 
-  us.pwm.surge_port_hi = clockwise(thrust->force.surge_port_hi);        // Reverse PWM (<1500) = Positive thrust!
-  us.pwm.surge_stbd_hi = counterclockwise(thrust->force.surge_stbd_hi); // Reverse PWM (<1500) = Negative thrust!
-  us.pwm.surge_port_lo = counterclockwise(thrust->force.surge_port_lo);// Reverse PWM (<1500) = Negative thrust!
-  us.pwm.surge_stbd_lo = clockwise(thrust->force.surge_stbd_lo);        // Reverse PWM (<1500) = Positive thrust!
-  us.pwm.sway_fwd = counterclockwise(thrust->force.sway_fwd);// Reverse PWM (<1500) = Negative thrust!
-  us.pwm.sway_aft = clockwise(thrust->force.sway_aft);                  // Reverse PWM (<1500) = Positive thrust!
-  us.pwm.heave_port_fwd = counterclockwise(thrust->force.heave_port_fwd);// Reverse PWM (<1500) = Negative thrust!
-  us.pwm.heave_stbd_fwd = clockwise(thrust->force.heave_stbd_fwd);        // Reverse PWM (<1500) = Positive thrust!
-  us.pwm.heave_port_aft = clockwise(thrust->force.heave_port_aft);        // Reverse PWM (<1500) = Positive thrust!
-  us.pwm.heave_stbd_aft = counterclockwise(thrust->force.heave_stbd_aft);// Reverse PWM (<1500) = Negative thrust!
+  us.pwm.surge_port_lo = counterclockwise(thrust->force.surge_port_lo, 0);
+  us.pwm.surge_stbd_lo = clockwise(thrust->force.surge_stbd_lo, 0);
 
+  us.pwm.sway_fwd = counterclockwise(thrust->force.sway_fwd, 1);
+  us.pwm.sway_aft = clockwise(thrust->force.sway_aft, 1);
+
+  us.pwm.heave_stbd_fwd = clockwise(thrust->force.heave_stbd_fwd, 2);
+  us.pwm.heave_stbd_aft = counterclockwise(thrust->force.heave_stbd_aft, 2);
+
+  us.pwm.heave_port_aft = clockwise(thrust->force.heave_port_aft, 3);
+  us.pwm.heave_port_fwd = counterclockwise(thrust->force.heave_port_fwd, 3);
   pwm.publish(us);
+
 }
 
 void ThrustCal::killback(const std_msgs::Empty::ConstPtr& thrust)
@@ -58,7 +81,7 @@ void ThrustCal::voltsbacken(const riptide_msgs::Bat::ConstPtr& bat_stat)
 
 void ThrustCal::loop()
 {
-  ros::Duration safe(2);
+  ros::Duration safe(0.05);
   ros::Rate rate(50);
   while (!ros::isShuttingDown())
   {
@@ -72,24 +95,37 @@ void ThrustCal::loop()
   }
 }
 
-int ThrustCal::counterclockwise(double raw_force)
+
+int ThrustCal::counterclockwise(double raw_force, int thruster)
 {
   int pwm = 1500;
-  if (!dead)
-  {
-    pwm = 1500 + static_cast<int>(raw_force * 14);
+  ROS_INFO("Force: %f", raw_force);
+  if(raw_force<0){
+    ROS_INFO("Raw force -");
+    pwm = 1500 + static_cast<int>(raw_force*ccw_coeffs[thruster][0]);
+  }else if(raw_force>0){
+    ROS_INFO("Raw force +");
+    ROS_INFO("CCW_Coeff: %f", ccw_coeffs[thruster][1]);
+    pwm = (int) (1500 + (raw_force*ccw_coeffs[thruster][1]));
+  }else{
+    ROS_INFO("Raw force 0");
+    pwm = 1500;
   }
+  ROS_INFO("PWM: %d", pwm);
   return pwm;
 }
 
-int ThrustCal::clockwise(double raw_force)
+int ThrustCal::clockwise(double raw_force, int thruster)
 {
   int pwm = 1500;
-
-  if (!dead)
-  {
-    pwm = 1500 - static_cast<int>(raw_force * 14);
+  if(raw_force<0){
+    pwm = 1500 + static_cast<int>(raw_force*cw_coeffs[thruster][0]);
+  }else if(raw_force>0){
+    pwm = 1500 + static_cast<int>(raw_force*cw_coeffs[thruster][1]);
+  }else{
+    pwm = 1500;
   }
+
 
   return pwm;
 }

--- a/riptide_controllers/src/pwm_controller.cpp
+++ b/riptide_controllers/src/pwm_controller.cpp
@@ -99,19 +99,13 @@ void ThrustCal::loop()
 int ThrustCal::counterclockwise(double raw_force, int thruster)
 {
   int pwm = 1500;
-  ROS_INFO("Force: %f", raw_force);
   if(raw_force<0){
-    ROS_INFO("Raw force -");
     pwm = 1500 + static_cast<int>(raw_force*ccw_coeffs[thruster][0]);
   }else if(raw_force>0){
-    ROS_INFO("Raw force +");
-    ROS_INFO("CCW_Coeff: %f", ccw_coeffs[thruster][1]);
     pwm = (int) (1500 + (raw_force*ccw_coeffs[thruster][1]));
   }else{
-    ROS_INFO("Raw force 0");
     pwm = 1500;
   }
-  ROS_INFO("PWM: %d", pwm);
   return pwm;
 }
 


### PR DESCRIPTION
The pwm controller was modified to allow for each thruster to have a specific thrust to pwm slope value. This allows for pwm calculations specific to each thruster and based on the necessary thrust.