### PR TITLE
Fixed dynamic reconfig in thruster controller, and fixed center of buoyancy code

### DIFF
--- a/riptide_bringup/launch/bringup.launch
+++ b/riptide_bringup/launch/bringup.launch
@@ -1,10 +1,6 @@
 <launch>
-  <arg name="tune" default="false" />
-
   <!--<include file="$(find riptide_hardware)/launch/hardware.launch" />-->
-  <include file="$(find riptide_controllers)/launch/controllers.launch" >
-    <arg name="tune" value="$(arg tune)" />
-  </include>
+  <include file="$(find riptide_controllers)/launch/controllers.launch" />
 
   <!--<include file="$(find riptide_hardware)/launch/cameras_jetson.launch" />-->
   <include file="$(find riptide_hardware)/launch/darknet_ros_jetson.launch" />

--- a/riptide_bringup/launch/tune_pid.launch
+++ b/riptide_bringup/launch/tune_pid.launch
@@ -1,9 +1,4 @@
 <launch>
-  <arg name="tune" default="false" />
-
   <include file="$(find riptide_hardware)/launch/coprocessor.launch" />
-  <include file="$(find riptide_controllers)/launch/controllers.launch" >
-    <arg name="tune" value="$(arg tune)" />
-  </include>
-
+  <include file="$(find riptide_controllers)/launch/controllers.launch" />
 </launch>

--- a/riptide_controllers/CMakeLists.txt
+++ b/riptide_controllers/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(catkin REQUIRED
 
 find_package(Ceres REQUIRED)
 
-find_package(Eigen3 3.3 REQUIRED)
+find_package(Eigen3 REQUIRED) #find_package(Eigen3 3.3 REQUIRED)
 
 generate_dynamic_reconfigure_options(
   cfg/VehicleProperties.cfg

--- a/riptide_controllers/include/riptide_controllers/thruster_controller.h
+++ b/riptide_controllers/include/riptide_controllers/thruster_controller.h
@@ -9,6 +9,7 @@
 #include "ros/ros.h"
 #include <dynamic_reconfigure/server.h>
 #include <riptide_controllers/VehiclePropertiesConfig.h>
+#include <boost/thread/mutex.hpp>
 
 #include "geometry_msgs/Vector3.h"
 #include "geometry_msgs/Vector3Stamped.h"
@@ -42,9 +43,10 @@ private:
   geometry_msgs::Vector3Stamped cob_msg;
 
   // Dynamic Reconfigure Setup
-  bool tune; // If true, key params can be input via messages
-  dynamic_reconfigure::Server<riptide_controllers::VehiclePropertiesConfig> server;
-  dynamic_reconfigure::Server<riptide_controllers::VehiclePropertiesConfig>::CallbackType cb;
+  typedef dynamic_reconfigure::Server<riptide_controllers::VehiclePropertiesConfig> DynamicReconfigServer;
+  boost::shared_ptr<DynamicReconfigServer> param_reconfig_server;
+  DynamicReconfigServer::CallbackType param_reconfig_callback;
+  boost::recursive_mutex param_reconfig_mutex;
 
   YAML::Node properties;
   string properties_file;
@@ -78,6 +80,7 @@ public:
   template <typename T>
   void LoadParam(std::string param, T &var);
   void LoadVehicleProperties();
+  void InitDynamicReconfigure();
   void SetThrusterCoeffs();
   void InitThrustMsg();
   void DynamicReconfigCallback(riptide_controllers::VehiclePropertiesConfig &config, uint32_t levels);
@@ -139,16 +142,14 @@ private:
   int x, y, z;           // Axis indeces
   MatrixXd thrustCoeffs; // Thrust coefficients (effective contributions of each thruster for force and moments)
   double *Fb;            // (Pointer) Buoyant forces along body-frame x, y, and x axes
-  double *transportThm;  // (Pointer) Vector containng terms related to the transport theorem
   double *forces;        // (Pointer) Solved thruster forces from class EOM
 
 public:
-  FindCoB(int &numThrust, const Ref<const MatrixXd> &thrustCoeffsIn, double *FbIn, double *transportThmIn, double *forcesIn)
+  FindCoB(int &numThrust, const Ref<const MatrixXd> &thrustCoeffsIn, double *FbIn, double *forcesIn)
   {
     numThrusters = numThrust;
     thrustCoeffs = thrustCoeffsIn;
     Fb = FbIn;
-    transportThm = transportThmIn;
     forces = forcesIn;
     x = 0, y = 1, z = 2;
   }
@@ -159,13 +160,14 @@ public:
   {
     for (int i = 0; i < 3; i++)
     {
-      residual[i] = T(transportThm[i + 3]);
+      residual[i] = T(0);
       for (int j = 0; j < numThrusters; j++)
-        residual[i] = residual[i] + T(thrustCoeffs(j, i) * forces[j]);
+        residual[i] = residual[i] + T(thrustCoeffs(i+3, j) * forces[j]);
     }
-    residual[x] = residual[x] + rFb[y] * Fb[z] - rFb[z] * Fb[y];
-    residual[y] = residual[y] + rFb[z] * Fb[x] - rFb[x] * Fb[z];
-    residual[z] = residual[z] + rFb[x] * Fb[y] - rFb[y] * Fb[x];
+    residual[x] = residual[x] + (rFb[y] * T(Fb[z]) - rFb[z] * T(Fb[y]));
+    residual[y] = residual[y] + (rFb[z] * T(Fb[x]) - rFb[x] * T(Fb[z]));
+    residual[z] = residual[z] + (rFb[x] * T(Fb[y]) - rFb[y] * T(Fb[x]));
+    return true;
   }
 };
 

--- a/riptide_controllers/launch/controllers.launch
+++ b/riptide_controllers/launch/controllers.launch
@@ -1,11 +1,6 @@
 <launch>
-  <arg name="tune" default="false" />
-
   <include file="$(find riptide_controllers)/launch/pwm_controller.launch" />
-  <include file="$(find riptide_controllers)/launch/thruster_controller.launch" >
-    <arg name="tune" value="$(arg tune)" />
-  </include>
-
+  <include file="$(find riptide_controllers)/launch/thruster_controller.launch" />
   <include file="$(find riptide_controllers)/launch/command_combinator.launch" />
   <include file="$(find riptide_controllers)/launch/depth_controller.launch" />
   <include file="$(find riptide_controllers)/launch/attitude_controller.launch" />

--- a/riptide_controllers/launch/thruster_controller.launch
+++ b/riptide_controllers/launch/thruster_controller.launch
@@ -1,9 +1,7 @@
 <launch>
-  <arg name="tune" default="false" />
   <arg name="properties_file" value="$(find riptide_controllers)/cfg/vehicle_properties.yaml" />
 
   <node pkg="riptide_controllers" type="thruster_controller" name="thruster_controller" output="screen" >
-    <param name="tune" type="bool" value="$(arg tune)" />
     <param name="properties_file" type="string" value="$(arg properties_file)" />
   </node>
 </launch>


### PR DESCRIPTION
Dynamic reconfig in thruster controller now initializes to the values in the vehicle_properties.yaml file
Buoyancy code that kept breaking now works.